### PR TITLE
Repaired error caused by deletion of file with insufficient permissions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bin/
 /testFileReader1.txt
 /state2.json
+.idea/
+logstash-forwarder-java.iml

--- a/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
+++ b/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
@@ -298,7 +298,8 @@ public class FileWatcher {
 	public void onFileDelete(File file) {
 		try {
 			logger.debug("Delete detected on file : " + file.getCanonicalPath());
-			oldWatchMap.get(file).setDeleted();
+			FileState state = oldWatchMap.get(file);
+			if (state != null) state.setDeleted();
 		} catch (IOException e) {
 			logger.error("Caught IOException : " + e.getMessage());
 		}


### PR DESCRIPTION
There was an error when a watched file has insufficient permissions and then it was deleted. The method onFileDelete in FileWatcher.java tried to mark it as deleted but it was not contained in the oldWatchMap so it caused NullPointerException.
