### PR TITLE
Repaired sincedb and deadtime

### DIFF
--- a/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
+++ b/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
@@ -48,7 +48,8 @@ public class FileWatcher {
 	private boolean stdinConfigured = false;
 	private String sincedbFile = null;
 
-	public FileWatcher() {
+	public FileWatcher(String sincedbFileName) {
+		sincedbFile = sincedbFileName;
 		try {
 			logger.debug("Loading saved states");
 			savedStates = Registrar.readStateFromJson(sincedbFile);
@@ -363,9 +364,4 @@ public class FileWatcher {
 	public void setTail(boolean tail) {
 		this.tail = tail;
 	}
-
-	public void setSincedb(String sincedbFile) {
-		this.sincedbFile = sincedbFile;	
-	}
-
 }

--- a/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
+++ b/src/main/java/info/fetter/logstashforwarder/FileWatcher.java
@@ -77,7 +77,7 @@ public class FileWatcher {
 		printWatchMap();
 	}
 
-	public void addFilesToWatch(String fileToWatch, Event fields, int deadTime) {
+	public void addFilesToWatch(String fileToWatch, Event fields, long deadTime) {
 		try {
 			if(fileToWatch.equals("-")) {
 				addStdIn(fields);
@@ -220,7 +220,7 @@ public class FileWatcher {
 		removeMarkedFilesFromWatchMap();
 	}
 
-	private void addSingleFile(String fileToWatch, Event fields, int deadTime) throws Exception {
+	private void addSingleFile(String fileToWatch, Event fields, long deadTime) throws Exception {
 		logger.info("Watching file : " + new File(fileToWatch).getCanonicalPath());
 		String directory = FilenameUtils.getFullPath(fileToWatch);
 		String fileName = FilenameUtils.getName(fileToWatch); 
@@ -231,7 +231,7 @@ public class FileWatcher {
 		initializeWatchMap(new File(directory), fileFilter, fields);
 	}
 
-	private void addWildCardFiles(String filesToWatch, Event fields, int deadTime) throws Exception {
+	private void addWildCardFiles(String filesToWatch, Event fields, long deadTime) throws Exception {
 		logger.info("Watching wildcard files : " + filesToWatch);
 		String directory = FilenameUtils.getFullPath(filesToWatch);
 		String wildcard = FilenameUtils.getName(filesToWatch);

--- a/src/main/java/info/fetter/logstashforwarder/Forwarder.java
+++ b/src/main/java/info/fetter/logstashforwarder/Forwarder.java
@@ -72,10 +72,9 @@ public class Forwarder {
 		try {
 			parseOptions(args);
 			setupLogging();
-			watcher = new FileWatcher();
+			watcher = new FileWatcher(sincedbFile);
 			watcher.setMaxSignatureLength(signatureLength);
 			watcher.setTail(tailSelected);
-			watcher.setSincedb(sincedbFile);
 			configManager = new ConfigurationManager(config);
 			configManager.readConfiguration();
 			for(FilesSection files : configManager.getConfig().getFiles()) {

--- a/src/main/java/info/fetter/logstashforwarder/config/FilesSection.java
+++ b/src/main/java/info/fetter/logstashforwarder/config/FilesSection.java
@@ -50,8 +50,8 @@ public class FilesSection {
 		return deadTime;
 	}
 
-	public int getDeadTimeInSeconds() {
-		int deadTimeInSeconds = 0;
+	public long getDeadTimeInSeconds() {
+		long deadTimeInSeconds = 0;
 		String remaining = deadTime;
 
 		if(deadTime.contains("h")) {

--- a/src/test/java/info/fetter/logstashforwarder/FileWatcherTest.java
+++ b/src/test/java/info/fetter/logstashforwarder/FileWatcherTest.java
@@ -46,7 +46,7 @@ public class FileWatcherTest {
 
 	//@Test
 	public void testFileWatch() throws InterruptedException, IOException {
-		FileWatcher watcher = new FileWatcher();
+		FileWatcher watcher = new FileWatcher(".logstash-forwarder-java");
 		watcher.addFilesToWatch("./test.txt", new Event().addField("test", "test"), FileWatcher.ONE_DAY);
 		for(int i = 0; i < 100; i++) {
 			Thread.sleep(1000);
@@ -60,7 +60,7 @@ public class FileWatcherTest {
 			logger.warn("Not executing this test on windows");
 			return;
 		}
-		FileWatcher watcher = new FileWatcher();
+		FileWatcher watcher = new FileWatcher(".logstash-forwarder-java");
 		watcher.addFilesToWatch("./testFileWatcher*.txt", new Event().addField("test", "test"), FileWatcher.ONE_DAY);
 		watcher.initialize();
 


### PR DESCRIPTION
This pull request repairs two things:
- The since db path needs to be set in FileWatcher constructor otherwise file states are not loaded
- The dead time parameter stores time threshold for old files in milliseconds which makes the number quite large. It is better to change type from int to long in case someone would use large value.
